### PR TITLE
Fixes List Version

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -14,5 +14,5 @@ function sort_versions() {
 }
 
 # Fetch all tag names, and get only second column. Then remove all unnecesary characters.
-versions=$(eval $cmd | grep -oE "tag_name\": \".{1,15}\"," | sed 's/tag_name\": \"v//;s/\",//' | sort_versions)
+versions=$(eval $cmd | grep -oE "tag_name\":\s?\".{1,15}\"," | grep -v 'rc' | sed -E 's/tag_name\":\s?\"v([0-9\.]+)\",/\1/'| sort_versions)
 echo $versions


### PR DESCRIPTION
* I'm not sure if it was an API change or what, however, it wasn't
initially working upon install
* This fixes up the grep to account for some spaces
* Adjusts the grep to rid of the release candidates as that broke the
final `sed`
* Updates the travis build file such that it'll properly test branches

Signed-off-by: John T Skarbek <jtslear@gmail.com>