### PR TITLE
Refactor list-all version parsing

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -14,5 +14,5 @@ function sort_versions() {
 }
 
 # Fetch all tag names, and get only second column. Then remove all unnecesary characters.
-versions=$(eval $cmd | grep -oE "tag_name\":\s?\".{1,15}\"," | grep -v 'rc' | sed -E 's/tag_name\":\s?\"v([0-9\.]+)\",/\1/'| sort_versions)
+versions=$(eval $cmd | grep -oE "tag_name\": *\".{1,15}\"," | sed 's/tag_name\": *\"v//;s/\",//' | sort_versions)
 echo $versions


### PR DESCRIPTION
In its previous state, there were some additional characters being appended to each version. This seems to work out okay - borrowed from https://github.com/Banno/asdf-kubectl/blob/master/bin/list-all#L17.

```bash
# Before

▸ bin/list-all
"v2.4.2",.z "v2.5.0",.z "v2.5.1",.z "v2.6.0",.z "v2.6.1",.z "v2.6.2",.z "v2.7.0",.z "v2.7.1",.z "v2.7.2",.z "v2.8.0",.z "v2.8.1",.z "v2.8.2",.z "v2.9.0",.z "v2.9.1",.z "v2.10.0",.z "v2.11.0",.z

# After

▸ bin/list-all
2.4.2 2.5.0 2.5.1 2.6.0 2.6.1 2.6.2 2.7.0-rc1 2.7.0 2.7.1 2.7.2 2.8.0-rc.1 2.8.0 2.8.1 2.8.2 2.9.0-rc1 2.9.0-rc2 2.9.0-rc3 2.9.0-rc4 2.9.0-rc5 2.9.0 2.9.1 2.10.0-rc.1 2.10.0-rc.2 2.10.0-rc.3 2.10.0 2.11.0-rc.1 2.11.0-rc.2 2.11.0-rc.3 2.11.0-rc.4 2.11.0
```