### PR TITLE
Install Apple M1 package (darwin-arm64) since helm > 3.6.0 supports that

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -45,7 +45,7 @@ getArch() {
     armv5*) ARCH="armv5";;
     armv6*) ARCH="armv6";;
     armv7*) ARCH="arm";;
-    arm64) ARCH="amd64";; # TODO Fix to proper when M1 packages are available
+    arm64) ARCH="arm64";; # TODO Fix to proper when M1 packages are available
     aarch64) ARCH="arm64";;
     x86) ARCH="386";;
     x86_64) ARCH="amd64";;


### PR DESCRIPTION
Hi, I _roughly_ fixed (uncommented) the `arm64` platform detection.
At least the Apple M1 users can install the `arm64` ready versions: `v3.6.0` and later.

refs: https://github.com/helm/helm/releases/tag/v3.6.0

### Known issue
If Apple M1 users want to install the `x86_64` version before `v3.6.0`, they have to run `asdf` with `arch`:

```
arch -x86_64 asdf install helm 3.5.4
```

Just like I did on my M1 previously.