### PR TITLE
Make curl retry on transient failures

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -23,7 +23,7 @@ install_helm() {
   local download_path="$tmp_download_dir/$(get_filename $version $platform)"
 
   echo "Downloading helm from ${download_url} to ${download_path}"
-  curl -Lo $download_path $download_url
+  curl --retry 10 --retry-delay 2 -Lo $download_path $download_url
 
   echo "Creating bin directory"
   mkdir -p "${bin_install_path}"

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 releases_path=https://api.github.com/repos/helm/helm/releases
-cmd="curl -s"
+cmd="curl --retry 10 --retry-delay 2 -s"
 if [ -n "$GITHUB_API_TOKEN" ]; then
   cmd="$cmd -H 'Authorization: token $GITHUB_API_TOKEN'"
 fi


### PR DESCRIPTION
Spotted a transient error that flaked our CI pipeline: 

<img width="927" alt="image" src="https://user-images.githubusercontent.com/10151/168034852-3d50a7ef-a161-453c-97c7-5a6a24f60ea6.png">

Making `curl` retry on its own is a rather low-hanging fruit to avoid these :)