### PR TITLE
Download a larger number of release versions

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -5,7 +5,7 @@ cmd="curl --retry 10 --retry-delay 2 -s"
 if [ -n "$GITHUB_API_TOKEN" ]; then
   cmd="$cmd -H 'Authorization: token $GITHUB_API_TOKEN'"
 fi
-cmd="$cmd $releases_path"
+cmd="$cmd ${releases_path}?per_page=100"
 
 # stolen from https://github.com/rbenv/ruby-build/pull/631/files#diff-fdcfb8a18714b33b07529b7d02b54f1dR942
 function sort_versions() {


### PR DESCRIPTION
By default, GitHub's releases API returns 30 releases, which is not
always enough (for example, when trying to replicate a bug using an
older version of helm that is used on the target system).

Changes in this commit bump the number of dowloaded releases to 100,
which should suffice for now. If we would like to download all releases,
we will need to handle API pagination, which is not fun thing to do from
bash.
