### PR TITLE
feat: adding variable to allow architecture override on M1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@
 asdf plugin-add helm https://github.com/Antiarchitect/asdf-helm.git
 ```
 
+### Environment Variable Options
+- ASDF_HELM_OVERWRITE_ARCH: force the plugin to use a specified processor architecture rather than the automatically detected value. Useful, for example, for allowing users on M1 Macs to install `amd64` binaries when there's no `arm64` binary available.
+
 ## Use
 
 Check out the [asdf](https://github.com/asdf-vm/asdf) readme for instructions on how to install and manage versions of Helm.

--- a/bin/install
+++ b/bin/install
@@ -40,19 +40,22 @@ install_helm() {
 
 # getArch discovers the architecture for this system.
 getArch() {
-  ARCH=$(uname -m)
-  case $ARCH in
-    armv5*) ARCH="armv5";;
-    armv6*) ARCH="armv6";;
-    armv7*) ARCH="arm";;
-    arm64) ARCH="arm64";; # TODO Fix to proper when M1 packages are available
-    aarch64) ARCH="arm64";;
-    x86) ARCH="386";;
-    x86_64) ARCH="amd64";;
-    i686) ARCH="386";;
-    i386) ARCH="386";;
-  esac
-  echo "$ARCH"
+  if [[ $ASDF_HELM_OVERWRITE_ARCH != "" ]]; then
+    echo "$ASDF_HELM_OVERWRITE_ARCH"
+  else
+    ARCH=$(uname -m)
+    case $ARCH in
+      armv5*) ARCH="armv5";;
+      armv6*) ARCH="armv6";;
+      armv7*) ARCH="arm";;
+      arm64) ARCH="arm64";; # TODO Fix to proper when M1 packages are available
+      aarch64) ARCH="arm64";;
+      x86) ARCH="386";;
+      x86_64) ARCH="amd64";;
+      i686) ARCH="386";;
+      i386) ARCH="386";;
+    esac
+  fi
 }
 
 get_filename() {

--- a/bin/list-all
+++ b/bin/list-all
@@ -5,7 +5,7 @@ cmd="curl --retry 10 --retry-delay 2 -s"
 if [ -n "$GITHUB_API_TOKEN" ]; then
   cmd="$cmd -H 'Authorization: token $GITHUB_API_TOKEN'"
 fi
-cmd="$cmd $releases_path"
+cmd="$cmd ${releases_path}?per_page=100"
 
 # stolen from https://github.com/rbenv/ruby-build/pull/631/files#diff-fdcfb8a18714b33b07529b7d02b54f1dR942
 function sort_versions() {


### PR DESCRIPTION
On M1 architectures, the helm below version 3.6.x is not available for arm architectures, making management through ASDF impossible, although MacOs can run in an emulated way on amd architectures the plugin did not allow downloading. 

With this simple change we can pass a variable to override the architecture and then be able to download old helm@2 versions like `2.17.0` and others not existing in arm <= `3.5.0`

Example of usage:
```
ASDF_HELM_OVERWRITE_ARCH=amd64 asdf install helm 2.17.0
```