### PR TITLE
feat: fail on curl 404 error

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -23,7 +23,7 @@ install_helm() {
   local download_path="$tmp_download_dir/$(get_filename $version $platform)"
 
   echo "Downloading helm from ${download_url} to ${download_path}"
-  curl --retry 10 --retry-delay 2 -Lo $download_path $download_url
+  curl --retry 10 --retry-delay 2 -fLo $download_path $download_url || { echo "Could not download $download_url" ; exit 1 ; }
 
   echo "Creating bin directory"
   mkdir -p "${bin_install_path}"


### PR DESCRIPTION
fixes #20

I would not say it is perfect, but I think it is much better.

example:
```sh
❯ asdf install helm 3.15
Downloading helm from https://get.helm.sh/helm-v3.15-linux-amd64.tar.gz to /tmp/helm_aHNdCQ/helm-v3.15-linux-amd64.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0   215    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404
Could not download https://get.helm.sh/helm-v3.15-linux-amd64.tar.gz
```