### PR TITLE
Fix permission error when ASDF_DATA_DIR is shared among multiple users

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -21,12 +21,13 @@ install_helm() {
   fi
 
   local download_path="$tmp_download_dir/$(get_filename $version $platform)"
+  local error_file_path="$tmp_download_dir/curl_error"
 
   echo "Downloading helm from ${download_url} to ${download_path}"
 
   # capture error message from curl in memory
-  curl --retry 10 --retry-delay 2 -fLo $download_path $download_url 2>/tmp/curl_error
-  ERROR=$(</tmp/curl_error)
+  curl --retry 10 --retry-delay 2 -fLo $download_path $download_url 2>$error_file_path
+  ERROR=$(<$error_file_path)
 
   # retry with http1.1 if http2 error
   if [[ $ERROR == *"HTTP/2 stream 0 was not closed cleanly"* ]]; then


### PR DESCRIPTION
## Problem

When installing helm using asdf-helm in an environment where multiple users share the same `ASDF_DATA_DIR`, the installation fails with a permission error:

```
Downloading helm from https://get.helm.sh/helm-v3.11.0-linux-amd64.tar.gz to /tmp/helm_b6Wszv/helm-v3.11.0-linux-amd64.tar.gz
/opt/asdf/.asdf/plugins/helm/bin/install: line 28: /tmp/curl_error: Permission denied
```

This occurs because the installation script attempts to write curl error output to `/tmp/curl_error`, but in shared environments, this file may be owned by another user, causing permission conflicts.

## Solution

Modified the curl error output path to use the temporary download directory instead of the global `/tmp/curl_error` file. This ensures that each installation process uses its own temporary space with appropriate permissions.

## Changes

- Changed curl error output destination from `/tmp/curl_error` to `${tmp_download_dir}/curl_error`
- This prevents permission conflicts in multi-user environments while maintaining the same error handling functionality

## Testing

- Confirmed that error handling still works correctly with the new path